### PR TITLE
feat: interactive simulation parameter configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,9 +111,25 @@ simulator.plot_comprehensive_results(results, save_dir="my_results")
 
 # 5. Lưu kết quả
 simulator.save_results(results, "simulation_results.pkl")
+
+### Chạy mô phỏng tương tác
+
+Bạn có thể chạy `run_simulation.py` để thiết lập tham số trước khi mô phỏng:
+
+```bash
+python run_simulation.py
+```
+
+Chương trình sẽ hiển thị các lựa chọn:
+
+1. Dùng tham số đã lưu  
+2. Dùng tham số mặc định  
+3. Tùy chỉnh tham số theo hướng dẫn
+
+Các tham số tùy chỉnh được lưu trong `config/user_params.json` và tự động sử dụng cho lần chạy sau nếu bạn không nhập giá trị mới.
 Advanced Usage
 pythonfrom optimized_nearfield_system import (
-    SystemParameters, 
+    SystemParameters,
     SimulationConfig,
     OptimizedNearFieldBeamformingSimulator
 )

--- a/config/user_params.json
+++ b/config/user_params.json
@@ -1,0 +1,5 @@
+{
+    "preset": "standard",
+    "mode": "fast",
+    "users": null
+}


### PR DESCRIPTION
## Summary
- add interactive menu to configure simulation parameters with guidance
- persist last-used parameters to `config/user_params.json`
- document interactive runner in README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c22c800ca48320a002ed88a296a83a