### PR TITLE
Fix GUI legend cropping and expose parameters in demo

### DIFF
--- a/optimized_nearfield_system.py
+++ b/optimized_nearfield_system.py
@@ -516,8 +516,10 @@ class OptimizedNearFieldBeamformingSimulator:
             plt.xlim(z_values[0] / self.params.lambda_, z_values[-1] / self.params.lambda_)
             plt.ylim(bottom=0)
 
+            # Ensure layout accommodates legend
+            fig.tight_layout(rect=[0, 0, 0.85, 1])
+
             if save_dir:
-                plt.tight_layout()
                 fig.savefig(
                     f"{save_dir}/aag_vs_distance_{num_users}users.png",
                     dpi=300,
@@ -571,7 +573,7 @@ class OptimizedNearFieldBeamformingSimulator:
                 label=f'Fraunhofer 2 = {self.d_F2:.1f}m',
                 alpha=0.7,
             )
-            
+
             plt.xlabel('Distance (z/λ)', fontsize=12)
             plt.ylabel('Average Minimum Array Gain (AMAG)', fontsize=12)
             plt.title(f'AMAG vs Distance - {num_users} Users', fontsize=14)
@@ -580,8 +582,9 @@ class OptimizedNearFieldBeamformingSimulator:
             plt.xlim(z_values[0] / self.params.lambda_, z_values[-1] / self.params.lambda_)
             plt.ylim(bottom=0)
 
+            fig.tight_layout(rect=[0, 0, 0.85, 1])
+
             if save_dir:
-                plt.tight_layout()
                 fig.savefig(
                     f"{save_dir}/amag_vs_distance_{num_users}users.png",
                     dpi=300,
@@ -616,8 +619,9 @@ class OptimizedNearFieldBeamformingSimulator:
             plt.xlim(left=0)
             plt.ylim(0, 1)
 
+            fig.tight_layout(rect=[0, 0, 0.85, 1])
+
             if save_dir:
-                plt.tight_layout()
                 fig.savefig(
                     f"{save_dir}/cdf_aag_{num_users}users.png",
                     dpi=300,


### PR DESCRIPTION
## Summary
- Prevent matplotlib legends from being clipped in GUI by tightening layout
- Allow demo fast simulation parameters via CLI and save run configuration

## Testing
- `python -m pytest`
- `python demo_script.py --demo fast --preset small_test --mode fast --users 5`

------
https://chatgpt.com/codex/tasks/task_e_68c239ae89d48320b868d5ced9079e25